### PR TITLE
Update Errno_unix

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,31 @@
+0.4.0 (trunk):
+* Changed the return type of Errno_unix.raise_on_errno to be 'a option
+* Changed the host parameters of Errno_unix.to_unix and
+  Errno_unix.of_unix to be optional (default Errno_unix.host)
+* Documented Errno_unix
+* Add Errno_unix.get_errno
+* Add Errno_unix.reset_errno
+* Add Errno_unix.raise_errno
+* Add Errno_unix.to_errno_exn
+* Add Errno_unix.with_errno_exn
+* Add Errno_unix.to_unix_exn
+* Add ENOTBLK, EREMOTE, and EUSERS which are available on Linux, OS X,
+  and FreeBSD
+* Add ECHRNG, EL2NSYNC, EL3HLT, EL3RST, ELNRNG, EUNATCH, ENOCSI, EL2HLT,
+  EBADE, EBADR, EXFULL, ENOANO, EBADRQC, EBADSLT, EBFONT, ENONET, ENOPKG,
+  EADV, ESRMNT, ECOMM, EDOTDOT, ENOTUNIQ, EBADFD, EREMCHG, ELIBACC,
+  ELIBBAD, ELIBSCN, ELIBMAX, ELIBEXEC, ERESTART, ESTRPIPE, EUCLEAN,
+  ENOTNAM, ENAVAIL, EISNAM, EREMOTEIO, ENOMEDIUM, EMEDIUMTYPE, ENOKEY,
+  EKEYEXPIRED, EKEYREVOKED, EKEYREJECTED, ERFKILL, and EHWPOISON which are
+  available on Linux only
+* Add EPWROFF, EDEVERR, EBADEXEC, EBADARCH, ESHLIBVERS, EBADMACHO,
+  ENOPOLICY, and EQFULL which are available on OS X only
+* Add EDOOFUS, ENOTCAPABLE, and ECAPMODE which are available on FreeBSD only
+* Add EPROCLIM, EBADRPC, ERPCMISMATCH, EPROGUNAVAIL, EPROGMISMATCH,
+  EPROCUNAVAIL, EFTYPE, EAUTH, ENEEDAUTH, and ENOATTR which are
+  available on OS X and FreeBSD
+* Add ENOSTR, ENODATA, ETIME, and ENOSR which are available on Linux and OS X
+
 0.3.0 (2015-11-30):
 * Use result instead of rresult
 * Split findlib package into errno and errno.unix (depopt ctypes+unix)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@ ocaml-unix-errno
 ================
 
 [ocaml-unix-errno](https://github.com/dsheets/ocaml-unix-errno) provides
-an errno variant similar to `Unix.error` but including POSIX 2008 and
-Linux-specific constructors. A macro definition type, `defns` is also
-provided in order to transport a specific errno-integer map as is the
-case with FUSE or 9p2000.u. The types and their functions reside in
-`Errno` and are independent of any Unix bindings. This makes the
+an errno variant similar to `Unix.error` but including POSIX 2008,
+Linux, OS X, and FreeBSD constructors. A macro definition type, `defns`
+is also provided in order to transport a specific errno-integer map as
+is the case with FUSE or 9p2000.u. The types and their functions reside
+in `Errno` and are independent of any Unix bindings. This makes the
 library's types usable from MirageOS on top of Xen. `Errno_unix`
 provides maps to and from `Unix.error`, the present host's errno map, an
 errno exception `Error`, and higher-order errno checking functions.

--- a/unix/errno_unix.ml
+++ b/unix/errno_unix.ml
@@ -413,16 +413,39 @@ let of_unix ?(host=host) = Unix.(function
   | EUNKNOWNERR x -> Errno.of_code ~host x
 )
 
-let raise_on_errno ?(call="") ?(label="") fn =
-  C.reset_errno ();
-  let r = fn () in
-  match C.get_errno () with
-  | 0 -> r
-  | code -> raise Errno.(Error { errno = of_code ~host code; call; label; })
+let get_errno = C.get_errno
 
-let with_unix_exn fn =
-  try fn ()
-  with Errno.Error { Errno.errno = err::_; call; label } as e ->
-    match to_unix ~host err with
-    | Some err -> raise (Unix.Unix_error (err,call,label))
-    | None -> raise e
+let reset_errno = C.reset_errno
+
+let raise_errno ?(call="") ?(label="") code =
+  raise Errno.(Error { errno = of_code ~host code; call; label; })
+
+let raise_on_errno ?(call="") ?(label="") fn =
+  reset_errno ();
+  match fn () with
+  | Some r -> r
+  | None -> raise_errno ~call ~label (get_errno ())
+
+let to_errno_exn = function
+  | Unix.Unix_error (err, call, label) ->
+    let errno = of_unix err in
+    Errno.Error { Errno.errno; call; label }
+  | exn -> exn
+
+let with_errno_exn fn = try fn () with e -> raise (to_errno_exn e)
+
+let rec unix_error_of_errno = function
+  | [] -> None
+  | err::rest -> match to_unix err with
+    | Some err -> Some err
+    | None -> unix_error_of_errno rest
+
+let to_unix_exn = function
+  | Errno.Error { Errno.errno; call; label } as e ->
+    begin match unix_error_of_errno errno with
+      | Some err -> Unix.Unix_error (err, call, label)
+      | None -> e
+    end
+  | exn -> exn
+
+let with_unix_exn fn = try fn () with e -> raise (to_unix_exn e)

--- a/unix/errno_unix.ml
+++ b/unix/errno_unix.ml
@@ -183,7 +183,7 @@ let optional_unknown ~host errno = match Errno.to_code ~host errno with
   | Some i -> Some (Unix.EUNKNOWNERR i)
   | None -> None
 
-let to_unix ~host = Errno.(function
+let to_unix ?(host=host) = Errno.(function
   | E2BIG -> Some Unix.E2BIG
   | EACCES -> Some Unix.EACCES
   | EADDRINUSE -> Some Unix.EADDRINUSE
@@ -341,7 +341,7 @@ let to_unix ~host = Errno.(function
   | EUNKNOWNERR x -> Some (Unix.EUNKNOWNERR x)
 )
 
-let of_unix ~host = Unix.(function
+let of_unix ?(host=host) = Unix.(function
   | E2BIG -> [Errno.E2BIG]
   | EACCES -> [Errno.EACCES]
   | EADDRINUSE -> [Errno.EADDRINUSE]

--- a/unix/errno_unix.mli
+++ b/unix/errno_unix.mli
@@ -17,9 +17,15 @@
 
 val host : Errno.Host.t
 
-val to_unix : host:Errno.Host.t -> Errno.t -> Unix.error option
+val to_unix : ?host:Errno.Host.t -> Errno.t -> Unix.error option
+(** [to_unix ?host errno] is the {!Unix.error} corresponding to
+    [errno] if one exists. If [host] is not supplied, {!host} will be
+    used. *)
 
-val of_unix : host:Errno.Host.t -> Unix.error -> Errno.t list
+val of_unix : ?host:Errno.Host.t -> Unix.error -> Errno.t list
+(** [of_unix ?host error] is the list of symbolic error numbers
+    corresponding to the {!Unix.error}, [error]. If [host] is not
+    supplied, {!host} will be used. *)
 
 val raise_on_errno : ?call:string -> ?label:string -> (unit -> 'a) -> 'a
 

--- a/unix/errno_unix.mli
+++ b/unix/errno_unix.mli
@@ -16,6 +16,8 @@
  *)
 
 val host : Errno.Host.t
+(** [host] is the bidirectional error number map for the host upon
+    which this code is executing. *)
 
 val to_unix : ?host:Errno.Host.t -> Errno.t -> Unix.error option
 (** [to_unix ?host errno] is the {!Unix.error} corresponding to
@@ -59,3 +61,6 @@ val to_unix_exn : exn -> exn
     Otherwise, [to_unix_exn] does not modify [exn]. *)
 
 val with_unix_exn : (unit -> 'a) -> 'a
+(** [with_unix_exn fn] raises {!Unix.Unix_error} instead of
+    {!Errno.Error} if [fn] raises the latter and an errno code exists
+    on the present host. *)

--- a/unix/errno_unix.mli
+++ b/unix/errno_unix.mli
@@ -27,6 +27,35 @@ val of_unix : ?host:Errno.Host.t -> Unix.error -> Errno.t list
     corresponding to the {!Unix.error}, [error]. If [host] is not
     supplied, {!host} will be used. *)
 
-val raise_on_errno : ?call:string -> ?label:string -> (unit -> 'a) -> 'a
+val get_errno : unit -> int
+(** [get_errno ()] returns the current value of the C [errno]
+    thread-local variable. *)
+
+val reset_errno : unit -> unit
+(** [reset_errno ()] sets the current value of the C [errno]
+    thread-local variable to 0. *)
+
+val raise_errno : ?call:string -> ?label:string -> int -> 'a
+(** [raise_errno ?call ?label errno] raises {!Errno.Error} after
+    converting [errno] to the appropriate variants via {!host}. [call]
+    and [label] default to the empty string. *)
+
+val raise_on_errno : ?call:string -> ?label:string -> (unit -> 'a option) -> 'a
+(** [raise_on_errno ?call ?label fn] raises {!Errno.Error} using the
+    code in the C [errno] variable if [fn] returns [None]. [call] and
+    [label] default to the empty string. *)
+
+val to_errno_exn : exn -> exn
+(** [to_errno_exn exn] converts [exn] into an {!Errno.Error} if it is
+    a {!Unix.Unix_error} and otherwise does not modify it. *)
+
+val with_errno_exn : (unit -> 'a) -> 'a
+(** [with_errno_exn fn] raises {!Errno.Error} instead of
+    {!Unix.Unix_error} if [fn] raises the latter. *)
+
+val to_unix_exn : exn -> exn
+(** [to_unix_exn exn] converts [exn] into a {!Unix.Unix_error} if it
+    is an {!Errno.Error} and an errno code exists on the present host.
+    Otherwise, [to_unix_exn] does not modify [exn]. *)
 
 val with_unix_exn : (unit -> 'a) -> 'a


### PR DESCRIPTION
Update and document the `Errno_unix` interface to make errno checking more reliable and expose useful functions that clients should not have to implement.